### PR TITLE
Fix formula

### DIFF
--- a/Formula/signadot-cli.rb
+++ b/Formula/signadot-cli.rb
@@ -6,7 +6,6 @@ class SignadotCli < Formula
   desc "Command-line interface for Signadot"
   homepage "https://signadot.com"
   version "0.3.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
For some reason, maybe goreleaser version, the goreleaser generated formula gave this problem:
```
22-08-09 scott@pavillion cli % brew install -v -d signadot-cli
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/signadot/homebrew-tap/Formula/signadot-cli.rb
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/signadot/homebrew-tap/Formula/signadot-cli.rb
Error: signadot-cli: wrong number of arguments (given 1, expected 0)
```

removing the bottled: line fixed it for me locally

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
